### PR TITLE
README: remove mp3-releated support information and issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ terms of browser capabilities.
 
 # Installing
 
-* Download the latest release from [releases page](https://github.com/bazukas/obs-linuxbrowser/releases) (built with mp3 support). Make sure the release version matches obs-studio version on your system. (Currently 20.0.1 for Ubuntu and 19.0.3 for Debian).
+* Download the latest release from [releases page](https://github.com/bazukas/obs-linuxbrowser/releases). Make sure the release version matches obs-studio version on your system. (Currently 20.0.1 for Ubuntu and 19.0.3 for Debian).
 * `mkdir -p $HOME/.config/obs-studio/plugins`
 * `tar xfvz linuxbrowser0.3.1-obs20.0.1-64bit.tgz -C $HOME/.config/obs-studio/plugins/`
 
@@ -21,7 +21,6 @@ who want to compile the plugin themselves.
 # Building
 
 ## Building CEF
-*Notice: public CEF releases have mp3 support turned off*
 
 * Download CEF standard binary release from http://opensource.spotify.com/cefbuilds/index.html
 * Extract and cd into folder
@@ -47,17 +46,3 @@ Run `make install` to copy plugin binaries into $HOME/.config/obs-studio/plugins
 You can enable flash by providing path to pepper flash library file and its version.
 Some distributions provide packages with the plugin, or you can extract one from google chrome installation.
 Flash version can be found in manifest.json that is usually found in same directory as .so file.
-
-# Known issues
-
-## No html5 mp3 support
-
-Our binary builds provided on the [releases page](https://github.com/bazukas/obs-linuxbrowser/releases)
-now have mp3 support. If you build the plugin yourself, you'll have to build CEF from scratch with proprietary
-codecs support enabled (takes 2-3 hours on i7 4770k with 16GB RAM).
-
-## Streamlabs/Muxy.io widgets don't work
-
-Unfortunately, currently those require either mp3 support or flash to be enabled in order to work properly
-(even if they are playing .ogg audio - developers are aware of this issue).
-Same issue might affect other similar services.


### PR DESCRIPTION
As of CEF 3325 (Chromium 65) mp3 support has been added to both CEF and Chromium. Given that fact mp3-related issues and support information saying that mp3 is disabled in official CEF builds should be removed from README.