### PR TITLE
Implement JS callbacks for active state change and visibility change

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ Run `make install` to copy plugin binaries into $HOME/.config/obs-studio/plugins
 You can enable flash by providing path to pepper flash library file and its version.
 Some distributions provide packages with the plugin, or you can extract one from google chrome installation.
 Flash version can be found in manifest.json that is usually found in same directory as .so file.
+
+# JavaScript bindings
+All bindings are children of `window.obsstudio`.
+
+## Callbacks
+* `onActiveChange(bool isActive)` – called whenever the source becomes activated or deactivated
+* `onVisibilityChange(bool isVisible)` – called whenever the source is shown or hidden

--- a/src/browser/browser-app.cpp
+++ b/src/browser/browser-app.cpp
@@ -125,7 +125,7 @@ static void *MessageThread(void *vptr)
 	struct zoom_message *zmsg = (struct zoom_message *) &msg;
 	struct scroll_message *smsg = (struct scroll_message *) &msg;
 	struct active_state_message* amsg = (struct active_state_message*) &msg;
-    struct visibility_message* vmsg = (struct visibility_message*) &msg;
+	struct visibility_message* vmsg = (struct visibility_message*) &msg;
 
 	while (true) {
 		received = msgrcv(ba->GetQueueId(), &msg, max_buf_size, 0, MSG_NOERROR);

--- a/src/browser/browser-app.cpp
+++ b/src/browser/browser-app.cpp
@@ -93,7 +93,7 @@ void BrowserApp::InitSharedData()
 	data = (struct shared_data *) mmap(NULL, sizeof(struct shared_data) + MAX_DATA_SIZE,
 			PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	if (data == MAP_FAILED) {
-		printf("Browser: data remapping faileda\n");
+		printf("Browser: data remapping failed\n");
 		return;
 	}
 
@@ -124,6 +124,8 @@ static void *MessageThread(void *vptr)
 	struct key_message *kmsg = (struct key_message *) &msg;
 	struct zoom_message *zmsg = (struct zoom_message *) &msg;
 	struct scroll_message *smsg = (struct scroll_message *) &msg;
+	struct active_state_message* amsg = (struct active_state_message*) &msg;
+    struct visibility_message* vmsg = (struct visibility_message*) &msg;
 
 	while (true) {
 		received = msgrcv(ba->GetQueueId(), &msg, max_buf_size, 0, MSG_NOERROR);
@@ -187,6 +189,12 @@ static void *MessageThread(void *vptr)
 			case MESSAGE_TYPE_SCROLL:
 				ba->GetClient()->SetScroll(ba->GetBrowser(),
 						smsg->vertical, smsg->horizontal);
+				break;
+			case MESSAGE_TYPE_ACTIVE_STATE_CHANGE:
+				ba->UpdateActiveStateJS(amsg->active);
+				break;
+			case MESSAGE_TYPE_VISIBILITY_CHANGE:
+				ba->UpdateVisibilityStateJS(vmsg->visible);
 				break;
 			}
 		}
@@ -260,4 +268,74 @@ void BrowserApp::OnContextInitialized()
 	client->SetScroll(browser, 0, 0);  /* workaround for scroll to bottom bug */
 
 	pthread_create(&message_thread, NULL, MessageThread, this);
+}
+
+void BrowserApp::OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+                                  CefRefPtr<CefV8Context> context)
+{
+	CefRefPtr<CefV8Value> globalObj = context->GetGlobal();
+
+	CefRefPtr<CefV8Value> obsStudioObj = CefV8Value::CreateObject(0, 0);
+	globalObj->SetValue("obsstudio", obsStudioObj, V8_PROPERTY_ATTRIBUTE_NONE);
+}
+
+bool BrowserApp::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
+                                          CefProcessId source_process,
+                                          CefRefPtr<CefProcessMessage> message)
+{
+	DCHECK(source_process == PID_BROWSER);
+
+	CefRefPtr<CefListValue> args = message->GetArgumentList();
+
+	if (message->GetName() == "Visibility") {
+		CefV8ValueList arguments{CefV8Value::CreateBool(args->GetBool(0))};
+		ExecuteJSFunction(browser, "onVisiblityChange", arguments);
+	} else if (message->GetName() == "Active") {
+		CefV8ValueList arguments{CefV8Value::CreateBool(args->GetBool(0))};
+		ExecuteJSFunction(browser, "onActiveChange", arguments);
+	} else {
+		return false;
+	}
+
+	return true;
+}
+
+void BrowserApp::ExecuteJSFunction(CefRefPtr<CefBrowser> browser, const char* functionName,
+                                   CefV8ValueList arguments)
+{
+	CefRefPtr<CefV8Context> context = browser->GetMainFrame()->GetV8Context();
+
+	context->Enter();
+
+	CefRefPtr<CefV8Value> globalObj = context->GetGlobal();
+	CefRefPtr<CefV8Value> obsStudioObj = globalObj->GetValue("obsstudio");
+	CefRefPtr<CefV8Value> jsFunction = obsStudioObj->GetValue(functionName);
+
+	if (jsFunction && jsFunction->IsFunction()) {
+		jsFunction->ExecuteFunction(NULL, arguments);
+	}
+
+	context->Exit();
+}
+
+bool BrowserApp::Execute(const CefString& name, CefRefPtr<CefV8Value> object,
+                         const CefV8ValueList& arguments, CefRefPtr<CefV8Value>& retval,
+                         CefString& exception)
+{
+	return true;
+}
+
+void BrowserApp::UpdateActiveStateJS(bool active)
+{
+	CefRefPtr<CefProcessMessage> msg{CefProcessMessage::Create("Active")};
+	msg->GetArgumentList()->SetBool(0, active);
+	this->browser->SendProcessMessage(PID_BROWSER, msg);
+}
+
+void BrowserApp::UpdateVisibilityStateJS(bool visible)
+{
+	CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create("Visibility");
+	CefRefPtr<CefListValue> args = msg->GetArgumentList();
+	args->SetBool(0, visible);
+	this->browser->SendProcessMessage(PID_BROWSER, msg);
 }

--- a/src/browser/browser-app.hpp
+++ b/src/browser/browser-app.hpp
@@ -32,8 +32,8 @@ public:
 	virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler()
 		OVERRIDE { return this; }
 
-    virtual CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler()
-        override { return this; }
+	virtual CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler()
+		override { return this; }
 
 	virtual void OnContextInitialized() OVERRIDE;
 
@@ -46,29 +46,29 @@ public:
 
 	CefRefPtr<BrowserClient> GetClient() { return client; }
 
-    virtual void OnContextCreated(CefRefPtr<CefBrowser> browser,
-                          CefRefPtr<CefFrame> frame,
-                          CefRefPtr<CefV8Context> context) override;
+	virtual void OnContextCreated(CefRefPtr<CefBrowser> browser,
+                                      CefRefPtr<CefFrame> frame,
+                                      CefRefPtr<CefV8Context> context) override;
 
-    virtual bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
-                                  CefProcessId source_process,
-                                  CefRefPtr<CefProcessMessage> message) override;
+	virtual bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
+                                              CefProcessId source_process,
+                                              CefRefPtr<CefProcessMessage> message) override;
 
-    void UpdateActiveStateJS(bool active);
-    void UpdateVisibilityStateJS(bool visible);
+	void UpdateActiveStateJS(bool active);
+	void UpdateVisibilityStateJS(bool visible);
 
-    virtual bool Execute(const CefString& name,
-                 CefRefPtr<CefV8Value> object,
-                 const CefV8ValueList& arguments,
-                 CefRefPtr<CefV8Value>& retval,
-                 CefString& exception) override;
+	virtual bool Execute(const CefString& name,
+                             CefRefPtr<CefV8Value> object,
+                             const CefV8ValueList& arguments,
+                             CefRefPtr<CefV8Value>& retval,
+                             CefString& exception) override;
 private:
 	void InitSharedData();
 	void UninitSharedData();
 
-    void ExecuteJSFunction(CefRefPtr<CefBrowser> browser,
-                           const char* functionName,
-                           CefV8ValueList arguments);
+	void ExecuteJSFunction(CefRefPtr<CefBrowser> browser,
+                               const char* functionName,
+                               CefV8ValueList arguments);
 
 private:
 	CefRefPtr<CefBrowser> browser;

--- a/src/browser/browser-app.hpp
+++ b/src/browser/browser-app.hpp
@@ -22,7 +22,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "shared.h"
 
 class BrowserApp : public CefApp,
-                   public CefBrowserProcessHandler {
+                   public CefBrowserProcessHandler,
+                   public CefRenderProcessHandler,
+                   public CefV8Handler {
 public:
 	BrowserApp(char *shm_name);
 	~BrowserApp();
@@ -30,19 +32,43 @@ public:
 	virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler()
 		OVERRIDE { return this; }
 
+    virtual CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler()
+        override { return this; }
+
 	virtual void OnContextInitialized() OVERRIDE;
 
-	int GetQueueId() { return qid; };
-	CefRefPtr<CefBrowser> GetBrowser() { return browser; };
+	int GetQueueId() { return qid; }
+	CefRefPtr<CefBrowser> GetBrowser() { return browser; }
 	void SizeChanged();
 	void UrlChanged(const char *url);
 	void CssChanged(const char *css_file);
 	void ReloadPage();
 
-	CefRefPtr<BrowserClient> GetClient() { return client; };
+	CefRefPtr<BrowserClient> GetClient() { return client; }
+
+    virtual void OnContextCreated(CefRefPtr<CefBrowser> browser,
+                          CefRefPtr<CefFrame> frame,
+                          CefRefPtr<CefV8Context> context) override;
+
+    virtual bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
+                                  CefProcessId source_process,
+                                  CefRefPtr<CefProcessMessage> message) override;
+
+    void UpdateActiveStateJS(bool active);
+    void UpdateVisibilityStateJS(bool visible);
+
+    virtual bool Execute(const CefString& name,
+                 CefRefPtr<CefV8Value> object,
+                 const CefV8ValueList& arguments,
+                 CefRefPtr<CefV8Value>& retval,
+                 CefString& exception) override;
 private:
 	void InitSharedData();
 	void UninitSharedData();
+
+    void ExecuteJSFunction(CefRefPtr<CefBrowser> browser,
+                           const char* functionName,
+                           CefV8ValueList arguments);
 
 private:
 	CefRefPtr<CefBrowser> browser;

--- a/src/plugin/main.c
+++ b/src/plugin/main.c
@@ -369,7 +369,7 @@ static void browser_key_click(void *vptr, const struct obs_key_event *event, boo
 			event->modifiers, chr);
 }
 
-static void cb_activate(void* vptr)
+static void browser_source_activate(void* vptr)
 {
 	reload_on_scene(vptr);
 
@@ -377,19 +377,19 @@ static void cb_activate(void* vptr)
 	browser_manager_send_active_state_change(data->manager, true);
 }
 
-static void cb_deactivate(void* vptr)
+static void browser_source_deactivate(void* vptr)
 {
 	struct browser_data* data = vptr;
 	browser_manager_send_active_state_change(data->manager, false);
 }
 
-static void cb_show(void* vptr)
+static void browser_source_show(void* vptr)
 {
 	struct browser_data* data = vptr;
 	browser_manager_send_visibility_change(data->manager, true);
 }
 
-static void cb_hide(void* vptr)
+static void browser_source_hide(void* vptr)
 {
 	struct browser_data* data = vptr;
 	browser_manager_send_visibility_change(data->manager, false);
@@ -419,10 +419,10 @@ bool obs_module_load(void)
 	info.focus          = browser_focus;
 	info.key_click      = browser_key_click;
 
-	info.activate       = cb_activate;
-	info.deactivate     = cb_deactivate;
-	info.show           = cb_show;
-	info.hide           = cb_hide;
+	info.activate       = browser_source_activate;
+	info.deactivate     = browser_source_deactivate;
+	info.show           = browser_source_show;
+	info.hide           = browser_source_hide;
 
 	obs_register_source(&info);
 	return true;

--- a/src/plugin/main.c
+++ b/src/plugin/main.c
@@ -371,28 +371,28 @@ static void browser_key_click(void *vptr, const struct obs_key_event *event, boo
 
 static void cb_activate(void* vptr)
 {
-    reload_on_scene(vptr);
+	reload_on_scene(vptr);
 
-    struct browser_data* data = vptr;
-    browser_manager_send_active_state_change(data->manager, true);
+	struct browser_data* data = vptr;
+	browser_manager_send_active_state_change(data->manager, true);
 }
 
 static void cb_deactivate(void* vptr)
 {
-    struct browser_data* data = vptr;
-    browser_manager_send_active_state_change(data->manager, false);
+	struct browser_data* data = vptr;
+	browser_manager_send_active_state_change(data->manager, false);
 }
 
 static void cb_show(void* vptr)
 {
-    struct browser_data* data = vptr;
-    browser_manager_send_visibility_change(data->manager, true);
+	struct browser_data* data = vptr;
+	browser_manager_send_visibility_change(data->manager, true);
 }
 
 static void cb_hide(void* vptr)
 {
-    struct browser_data* data = vptr;
-    browser_manager_send_visibility_change(data->manager, false);
+	struct browser_data* data = vptr;
+	browser_manager_send_visibility_change(data->manager, false);
 }
 
 bool obs_module_load(void)

--- a/src/plugin/main.c
+++ b/src/plugin/main.c
@@ -369,6 +369,32 @@ static void browser_key_click(void *vptr, const struct obs_key_event *event, boo
 			event->modifiers, chr);
 }
 
+static void cb_activate(void* vptr)
+{
+    reload_on_scene(vptr);
+
+    struct browser_data* data = vptr;
+    browser_manager_send_active_state_change(data->manager, true);
+}
+
+static void cb_deactivate(void* vptr)
+{
+    struct browser_data* data = vptr;
+    browser_manager_send_active_state_change(data->manager, false);
+}
+
+static void cb_show(void* vptr)
+{
+    struct browser_data* data = vptr;
+    browser_manager_send_visibility_change(data->manager, true);
+}
+
+static void cb_hide(void* vptr)
+{
+    struct browser_data* data = vptr;
+    browser_manager_send_visibility_change(data->manager, false);
+}
+
 bool obs_module_load(void)
 {
 	struct obs_source_info info = {};
@@ -387,12 +413,16 @@ bool obs_module_load(void)
 	info.video_tick     = browser_tick;
 	info.video_render   = browser_render;
 
-	info.activate       = reload_on_scene;
 	info.mouse_click    = browser_mouse_click;
 	info.mouse_move     = browser_mouse_move;
 	info.mouse_wheel    = browser_mouse_wheel;
 	info.focus          = browser_focus;
 	info.key_click      = browser_key_click;
+
+	info.activate       = cb_activate;
+	info.deactivate     = cb_deactivate;
+	info.show           = cb_show;
+	info.hide           = cb_hide;
 
 	obs_register_source(&info);
 	return true;

--- a/src/plugin/manager.c
+++ b/src/plugin/manager.c
@@ -354,3 +354,25 @@ void browser_manager_send_key(browser_manager_t *manager, bool key_up, uint32_t 
 
 	msgsnd(manager->qid, &buf, sizeof(struct key_message), 0);
 }
+
+void browser_manager_send_active_state_change(browser_manager_t* manager, bool active)
+{
+    if (manager->qid == -1)
+        return;
+
+    struct active_state_message buf;
+    buf.type = MESSAGE_TYPE_ACTIVE_STATE_CHANGE;
+    buf.active = active;
+    msgsnd(manager->qid, &buf, sizeof(struct active_state_message), 0);
+}
+
+void browser_manager_send_visibility_change(browser_manager_t* manager, bool visible)
+{
+    if (manager->qid == -1)
+        return;
+
+    struct visibility_message buf;
+    buf.type = MESSAGE_TYPE_VISIBILITY_CHANGE;
+    buf.visible = visible;
+    msgsnd(manager->qid, &buf, sizeof(struct visibility_message), 0);
+}

--- a/src/plugin/manager.c
+++ b/src/plugin/manager.c
@@ -357,22 +357,22 @@ void browser_manager_send_key(browser_manager_t *manager, bool key_up, uint32_t 
 
 void browser_manager_send_active_state_change(browser_manager_t* manager, bool active)
 {
-    if (manager->qid == -1)
-        return;
+	if (manager->qid == -1)
+		return;
 
-    struct active_state_message buf;
-    buf.type = MESSAGE_TYPE_ACTIVE_STATE_CHANGE;
-    buf.active = active;
-    msgsnd(manager->qid, &buf, sizeof(struct active_state_message), 0);
+	struct active_state_message buf;
+	buf.type = MESSAGE_TYPE_ACTIVE_STATE_CHANGE;
+	buf.active = active;
+	msgsnd(manager->qid, &buf, sizeof(struct active_state_message), 0);
 }
 
 void browser_manager_send_visibility_change(browser_manager_t* manager, bool visible)
 {
-    if (manager->qid == -1)
-        return;
+	if (manager->qid == -1)
+		return;
 
-    struct visibility_message buf;
-    buf.type = MESSAGE_TYPE_VISIBILITY_CHANGE;
-    buf.visible = visible;
-    msgsnd(manager->qid, &buf, sizeof(struct visibility_message), 0);
+	struct visibility_message buf;
+	buf.type = MESSAGE_TYPE_VISIBILITY_CHANGE;
+	buf.visible = visible;
+	msgsnd(manager->qid, &buf, sizeof(struct visibility_message), 0);
 }

--- a/src/plugin/manager.h
+++ b/src/plugin/manager.h
@@ -56,3 +56,5 @@ void browser_manager_send_mouse_wheel(browser_manager_t *manager, int32_t x, int
 void browser_manager_send_focus(browser_manager_t *manager, bool focus);
 void browser_manager_send_key(browser_manager_t *manager, bool key_up, uint32_t native_vkey,
 		uint32_t modifiers, char chr);
+void browser_manager_send_active_state_change(browser_manager_t* manager, bool active);
+void browser_manager_send_visibility_change(browser_manager_t* manager, bool visible);

--- a/src/shared.h
+++ b/src/shared.h
@@ -111,11 +111,11 @@ struct scroll_message {
 };
 
 struct active_state_message {
-    long type;
-    bool active;
+	long type;
+	bool active;
 };
 
 struct visibility_message {
-    long type;
-    bool visible;
+	long type;
+	bool visible;
 };

--- a/src/shared.h
+++ b/src/shared.h
@@ -46,6 +46,8 @@ struct shared_data {
 #define MESSAGE_TYPE_SCROLLBARS 10
 #define MESSAGE_TYPE_ZOOM 11
 #define MESSAGE_TYPE_SCROLL 12
+#define MESSAGE_TYPE_ACTIVE_STATE_CHANGE 13
+#define MESSAGE_TYPE_VISIBILITY_CHANGE 14
 
 struct generic_message {
 	long type;
@@ -106,4 +108,14 @@ struct scroll_message {
 	long type;
 	uint32_t vertical;
 	uint32_t horizontal;
+};
+
+struct active_state_message {
+    long type;
+    bool active;
+};
+
+struct visibility_message {
+    long type;
+    bool visible;
 };


### PR DESCRIPTION
This PR provides two JavaScript callbacks `window.obsstudio.onActiveChange(bool isActive)` and `window.obsstudio.onVisibilityChange (bool isVisible)`.

Closes #48.