### PR TITLE
[Proposal] Add clang format for automatic source code formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 BasedOnStyle: LLVM                                          # LLVM, Google, Chromium, Mozilla, WebKit
-AccessModifierOffset: -4
+AccessModifierOffset: -8
 AlignEscapedNewlinesLeft: true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
@@ -34,8 +34,8 @@ BreakConstructorInitializers: BeforeComma
 ColumnLimit: 100
 # CommentPragmas
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 2
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat: false
@@ -55,7 +55,7 @@ IncludeBlocks: Preserve
 #      Priority: 5
 IndentCaseLabels: false
 # IndentPPDirectives: false
-IndentWidth: 4
+IndentWidth: 8
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false
 Language: Cpp                                               # None, Cpp, JavaScript, Proto
@@ -81,5 +81,5 @@ SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard: Cpp11                                             # Cpp03, Cpp11, Auto
-TabWidth: 4
+TabWidth: 8
 UseTab: ForIndentation                                      # Never(false), ForIndentation, Always(true)

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,85 @@
+BasedOnStyle: LLVM                                          # LLVM, Google, Chromium, Mozilla, WebKit
+AccessModifierOffset: -4
+AlignEscapedNewlinesLeft: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false                     # None(false), Inline, All(true)
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: NonAssignment                   # None, NonAssignment, All
+BreakBeforeBraces: Custom                                   # Attach, Linux, Stroustrup, Allman, GNU
+BraceWrapping:
+    AfterClass: false
+    AfterControlStatement: false
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterStruct: false
+    AfterUnion: false
+    AfterExternBlock: true
+    BeforeCatch: true
+    BeforeElse: false
+    IndentBraces: false
+    SplitEmptyFunction: false
+    SplitEmptyNamespace: true
+BreakBeforeInheritanceComma: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+ColumnLimit: 100
+# CommentPragmas
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+# ForEachMacros
+IncludeBlocks: Preserve
+#IncludeCategories:
+#    - Regex: '^c?std.*'
+#      Priority: 1
+#    - Regex: '^obs'
+#      Priority: 2
+#    - Regex: '^(include/)?cef.*'
+#      Priority: 3
+#    - Regex: '.h$'
+#      Priority: 4
+#    - Regex: '.hpp$'
+#      Priority: 5
+IndentCaseLabels: false
+# IndentPPDirectives: false
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+Language: Cpp                                               # None, Cpp, JavaScript, Proto
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner                                 # None, Inner, All
+# ObjCSpaceAfterProperty
+# ObjCSpaceBeforeProtocolList
+#// PenaltyBreakBeforeFirstCallParameter
+#// PenaltyBreakComment
+#// PenaltyBreakFirstLessLess
+#// PenaltyBreakString
+#// PenaltyExcessCharacter
+#// PenaltyReturnTypeOnItsOwnLine:
+PointerAlignment: Left                                      # Left, Right, Middle
+SpaceAfterCStyleCast: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements                        # Never, ControlStatements, Always
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11                                             # Cpp03, Cpp11, Auto
+TabWidth: 4
+UseTab: ForIndentation                                      # Never(false), ForIndentation, Always(true)

--- a/src/browser/base64.cpp
+++ b/src/browser/base64.cpp
@@ -29,16 +29,17 @@ René Nyffenegger rene.nyffenegger@adp-gmbh.ch
 #include <iostream>
 
 static const std::string base64_chars =
-"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-"abcdefghijklmnopqrstuvwxyz"
-"0123456789+/";
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  "abcdefghijklmnopqrstuvwxyz"
+  "0123456789+/";
 
-
-static inline bool is_base64(unsigned char c) {
+static inline bool is_base64(unsigned char c)
+{
 	return (isalnum(c) || (c == '+') || (c == '/'));
 }
 
-std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len) {
+std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len)
+{
 	std::string ret;
 	int i = 0;
 	int j = 0;
@@ -53,14 +54,13 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
 			char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
 			char_array_4[3] = char_array_3[2] & 0x3f;
 
-			for (i = 0; (i <4); i++)
+			for (i = 0; (i < 4); i++)
 				ret += base64_chars[char_array_4[i]];
 			i = 0;
 		}
 	}
 
-	if (i)
-	{
+	if (i) {
 		for (j = i; j < 3; j++)
 			char_array_3[j] = '\0';
 
@@ -74,14 +74,13 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
 
 		while ((i++ < 3))
 			ret += '=';
-
 	}
 
 	return ret;
-
 }
 
-std::string base64_decode(std::string const& encoded_string) {
+std::string base64_decode(std::string const& encoded_string)
+{
 	int in_len = encoded_string.size();
 	int i = 0;
 	int j = 0;
@@ -90,9 +89,10 @@ std::string base64_decode(std::string const& encoded_string) {
 	std::string ret;
 
 	while (in_len-- && (encoded_string[in_] != '=') && is_base64(encoded_string[in_])) {
-		char_array_4[i++] = encoded_string[in_]; in_++;
+		char_array_4[i++] = encoded_string[in_];
+		in_++;
 		if (i == 4) {
-			for (i = 0; i <4; i++)
+			for (i = 0; i < 4; i++)
 				char_array_4[i] = base64_chars.find(char_array_4[i]);
 
 			char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
@@ -106,17 +106,18 @@ std::string base64_decode(std::string const& encoded_string) {
 	}
 
 	if (i) {
-		for (j = i; j <4; j++)
+		for (j = i; j < 4; j++)
 			char_array_4[j] = 0;
 
-		for (j = 0; j <4; j++)
+		for (j = 0; j < 4; j++)
 			char_array_4[j] = base64_chars.find(char_array_4[j]);
 
 		char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
 		char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
 		char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
 
-		for (j = 0; (j < i - 1); j++) ret += char_array_3[j];
+		for (j = 0; (j < i - 1); j++)
+			ret += char_array_3[j];
 	}
 
 	return ret;

--- a/src/browser/base64.cpp
+++ b/src/browser/base64.cpp
@@ -1,7 +1,7 @@
 /*
 base64.cpp and base64.h
 
-Copyright (C) 2004-2008 René Nyffenegger
+Copyright (C) 2004-2008 Renï¿½ Nyffenegger
 
 This source code is provided 'as-is', without any express or implied
 warranty. In no event will the author be held liable for any damages
@@ -21,7 +21,7 @@ misrepresented as being the original source code.
 
 3. This notice may not be removed or altered from any source distribution.
 
-René Nyffenegger rene.nyffenegger@adp-gmbh.ch
+Renï¿½ Nyffenegger rene.nyffenegger@adp-gmbh.ch
 
 */
 

--- a/src/browser/browser-app.hpp
+++ b/src/browser/browser-app.hpp
@@ -21,25 +21,38 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "browser-client.hpp"
 #include "shared.h"
 
-class BrowserApp : public CefApp,
-                   public CefBrowserProcessHandler {
+class BrowserApp
+    : public CefApp
+    , public CefBrowserProcessHandler {
 public:
-	BrowserApp(char *shm_name);
+	BrowserApp(char* shm_name);
 	~BrowserApp();
 
-	virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler()
-		OVERRIDE { return this; }
+	virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() OVERRIDE
+	{
+		return this;
+	}
 
 	virtual void OnContextInitialized() OVERRIDE;
 
-	int GetQueueId() { return qid; };
-	CefRefPtr<CefBrowser> GetBrowser() { return browser; };
+	int GetQueueId()
+	{
+		return qid;
+	};
+	CefRefPtr<CefBrowser> GetBrowser()
+	{
+		return browser;
+	};
 	void SizeChanged();
-	void UrlChanged(const char *url);
-	void CssChanged(const char *css_file);
+	void UrlChanged(const char* url);
+	void CssChanged(const char* css_file);
 	void ReloadPage();
 
-	CefRefPtr<BrowserClient> GetClient() { return client; };
+	CefRefPtr<BrowserClient> GetClient()
+	{
+		return client;
+	};
+
 private:
 	void InitSharedData();
 	void UninitSharedData();
@@ -48,13 +61,13 @@ private:
 	CefRefPtr<CefBrowser> browser;
 	CefRefPtr<BrowserClient> client;
 	pthread_t message_thread;
-	char *shm_name;
+	char* shm_name;
 	uint32_t width;
 	uint32_t height;
 	int fps;
 	int fd;
 	int qid;
-	struct shared_data *data;
+	struct shared_data* data;
 	std::string css;
 	int in_fd;
 	int in_wd = -1;

--- a/src/browser/browser-client.cpp
+++ b/src/browser/browser-client.cpp
@@ -21,12 +21,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "base64.hpp"
 #include "browser-client.hpp"
 
-BrowserClient::BrowserClient(struct shared_data *data, std::string css) {
+BrowserClient::BrowserClient(struct shared_data* data, std::string css)
+{
 	this->data = data;
 	this->css = css;
 }
 
-bool BrowserClient::GetViewRect(CefRefPtr<CefBrowser> browser, CefRect &rect)
+bool BrowserClient::GetViewRect(CefRefPtr<CefBrowser> browser, CefRect& rect)
 {
 	pthread_mutex_lock(&data->mutex);
 	rect.Set(0, 0, data->width, data->height);
@@ -35,7 +36,8 @@ bool BrowserClient::GetViewRect(CefRefPtr<CefBrowser> browser, CefRect &rect)
 }
 
 void BrowserClient::OnPaint(CefRefPtr<CefBrowser> browser, CefRenderHandler::PaintElementType type,
-	const CefRenderHandler::RectList &dirtyRects, const void *buffer, int vwidth, int vheight)
+                            const CefRenderHandler::RectList& dirtyRects, const void* buffer,
+                            int vwidth, int vheight)
 {
 	/* don't draw popups for now */
 	if (type == PET_VIEW) {
@@ -46,11 +48,12 @@ void BrowserClient::OnPaint(CefRefPtr<CefBrowser> browser, CefRenderHandler::Pai
 	}
 }
 
-void BrowserClient::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode)
+void BrowserClient::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+                              int httpStatusCode)
 {
 	if (frame->IsMain() && css != "") {
-		std::string base64EncodedCSS = base64_encode(reinterpret_cast<const unsigned char*>(css.c_str()),
-				css.length());
+		std::string base64EncodedCSS =
+		  base64_encode(reinterpret_cast<const unsigned char*>(css.c_str()), css.length());
 		std::string href = "data:text/css;charset=utf-8;base64," + base64EncodedCSS;
 
 		std::string script = "";
@@ -72,10 +75,10 @@ void BrowserClient::SetScrollbars(CefRefPtr<CefBrowser> browser, bool show)
 	CefRefPtr<CefFrame> frame = browser->GetMainFrame();
 	if (show) {
 		frame->ExecuteJavaScript(std::string("document.documentElement.style.overflow = 'auto';"),
-			frame->GetURL(), 0);
+		                         frame->GetURL(), 0);
 	} else {
 		frame->ExecuteJavaScript(std::string("document.documentElement.style.overflow = 'hidden';"),
-			frame->GetURL(), 0);
+		                         frame->GetURL(), 0);
 	}
 	SetScroll(browser, scroll_vertical, scroll_horizontal);
 }

--- a/src/browser/browser-client.hpp
+++ b/src/browser/browser-client.hpp
@@ -20,31 +20,40 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "shared.h"
 
-class BrowserClient : public CefClient,
-                      public CefRenderHandler,
-		      public CefLoadHandler {
+class BrowserClient
+    : public CefClient
+    , public CefRenderHandler
+    , public CefLoadHandler {
 public:
-	BrowserClient(struct shared_data *data, std::string css);
+	BrowserClient(struct shared_data* data, std::string css);
 
-	virtual CefRefPtr<CefRenderHandler> GetRenderHandler()
-		OVERRIDE { return this; }
-	virtual CefRefPtr<CefLoadHandler> GetLoadHandler()
-		OVERRIDE { return this; }
+	virtual CefRefPtr<CefRenderHandler> GetRenderHandler() OVERRIDE
+	{
+		return this;
+	}
+	virtual CefRefPtr<CefLoadHandler> GetLoadHandler() OVERRIDE
+	{
+		return this;
+	}
 
-	virtual bool GetViewRect(CefRefPtr<CefBrowser> browser, CefRect &rect) OVERRIDE;
+	virtual bool GetViewRect(CefRefPtr<CefBrowser> browser, CefRect& rect) OVERRIDE;
 	virtual void OnPaint(CefRefPtr<CefBrowser> browser, CefRenderHandler::PaintElementType type,
-			const CefRenderHandler::RectList &dirtyRects, const void *buffer,
-			int width, int height) OVERRIDE;
+	                     const CefRenderHandler::RectList& dirtyRects, const void* buffer,
+	                     int width, int height) OVERRIDE;
 
 	virtual void OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
-			int httpStatusCode) OVERRIDE;
+	                       int httpStatusCode) OVERRIDE;
 
-	void ChangeCss(std::string css) { this->css = css; };
+	void ChangeCss(std::string css)
+	{
+		this->css = css;
+	};
 	void SetScrollbars(CefRefPtr<CefBrowser> browser, bool show);
 	void SetZoom(CefRefPtr<CefBrowser> browser, uint32_t zoom);
 	void SetScroll(CefRefPtr<CefBrowser> browser, uint32_t vertical, uint32_t horizontal);
+
 private:
-	struct shared_data *data;
+	struct shared_data* data;
 	std::string css;
 	bool show_scrollbars = true;
 	uint32_t zoom;

--- a/src/browser/browser-subprocess.cpp
+++ b/src/browser/browser-subprocess.cpp
@@ -18,7 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "browser-app.hpp"
 
-int main(int argc, char* argv[]) {
+int main(int argc, char* argv[])
+{
 	CefMainArgs main_args(argc, argv);
 	CefRefPtr<BrowserApp> app(new BrowserApp(NULL));
 	return CefExecuteProcess(main_args, app.get(), NULL);

--- a/src/plugin/main.c
+++ b/src/plugin/main.c
@@ -14,22 +14,22 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "manager.h"
+
 #include <obs-module.h>
 #include <pthread.h>
 #include <stdio.h>
-
-#include "manager.h"
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("linuxbrowser-source", "en-US")
 
 struct browser_data {
 	/* settings */
-	char *url;
+	char* url;
 	uint32_t width;
 	uint32_t height;
 	uint32_t fps;
-	char *css_file;
+	char* css_file;
 	bool hide_scrollbars;
 	uint32_t zoom;
 	uint32_t scroll_vertical;
@@ -37,15 +37,15 @@ struct browser_data {
 	bool reload_on_scene;
 
 	/* internal data */
-	obs_source_t *source;
-	gs_texture_t *activeTexture;
+	obs_source_t* source;
+	gs_texture_t* activeTexture;
 	pthread_mutex_t textureLock;
-	browser_manager_t *manager;
+	browser_manager_t* manager;
 
 	obs_hotkey_id reload_page_key;
 };
 
-static const char* browser_get_name(void *unused)
+static const char* browser_get_name(void* unused)
 {
 	UNUSED_PARAMETER(unused);
 	return obs_module_text("LinuxBrowser");
@@ -53,9 +53,9 @@ static const char* browser_get_name(void *unused)
 
 /* update stored parameters, see if they have changed and call
  * browser_manager methods based on that */
-static void browser_update(void *vptr, obs_data_t *settings)
+static void browser_update(void* vptr, obs_data_t* settings)
 {
-	struct browser_data *data = vptr;
+	struct browser_data* data = vptr;
 
 	uint32_t width = obs_data_get_int(settings, "width");
 	uint32_t height = obs_data_get_int(settings, "height");
@@ -70,17 +70,17 @@ static void browser_update(void *vptr, obs_data_t *settings)
 	data->reload_on_scene = obs_data_get_bool(settings, "reload_on_scene");
 
 	bool is_local = obs_data_get_bool(settings, "is_local_file");
-	const char *url;
+	const char* url;
 	if (is_local)
 		url = obs_data_get_string(settings, "local_file");
 	else
 		url = obs_data_get_string(settings, "url");
 
-	const char *css_file = obs_data_get_string(settings, "css_file");
+	const char* css_file = obs_data_get_string(settings, "css_file");
 
 	if (!data->manager)
 		data->manager = create_browser_manager(data->width, data->height, data->fps, settings,
-					obs_source_get_name(data->source));
+		                                       obs_source_get_name(data->source));
 
 	if (data->hide_scrollbars != hide_scrollbars) {
 		data->hide_scrollbars = hide_scrollbars;
@@ -130,33 +130,34 @@ static void browser_update(void *vptr, obs_data_t *settings)
 	pthread_mutex_unlock(&data->textureLock);
 }
 
-static void reload_hotkey_pressed(void *vptr, obs_hotkey_id id, obs_hotkey_t *key, bool pressed)
+static void reload_hotkey_pressed(void* vptr, obs_hotkey_id id, obs_hotkey_t* key, bool pressed)
 {
 	UNUSED_PARAMETER(id);
 	UNUSED_PARAMETER(key);
 	UNUSED_PARAMETER(pressed);
 
-	struct browser_data *data = vptr;
+	struct browser_data* data = vptr;
 	browser_manager_change_css_file(data->manager, data->css_file);
 	browser_manager_reload_page(data->manager);
 }
 
-static void *browser_create(obs_data_t *settings, obs_source_t *source)
+static void* browser_create(obs_data_t* settings, obs_source_t* source)
 {
-	struct browser_data *data = bzalloc(sizeof(struct browser_data));
+	struct browser_data* data = bzalloc(sizeof(struct browser_data));
 	data->source = source;
 	pthread_mutex_init(&data->textureLock, NULL);
 
 	browser_update(data, settings);
 
-	data->reload_page_key = obs_hotkey_register_source(source, "linuxbrowser.reloadpage",
-			obs_module_text("ReloadPage"), reload_hotkey_pressed, data);
+	data->reload_page_key =
+	  obs_hotkey_register_source(source, "linuxbrowser.reloadpage", obs_module_text("ReloadPage"),
+	                             reload_hotkey_pressed, data);
 	return data;
 }
 
-static void browser_destroy(void *vptr)
+static void browser_destroy(void* vptr)
 {
-	struct browser_data *data = vptr;
+	struct browser_data* data = vptr;
 	if (!data)
 		return;
 
@@ -180,24 +181,23 @@ static void browser_destroy(void *vptr)
 	bfree(data);
 }
 
-static uint32_t browser_get_width(void *vptr)
+static uint32_t browser_get_width(void* vptr)
 {
-	struct browser_data *data = vptr;
+	struct browser_data* data = vptr;
 	return data->width;
 }
 
-static uint32_t browser_get_height(void *vptr)
+static uint32_t browser_get_height(void* vptr)
 {
-	struct browser_data *data = vptr;
+	struct browser_data* data = vptr;
 	return data->height;
 }
 
-
-static bool reload_button_clicked(obs_properties_t *props, obs_property_t *property, void *vptr)
+static bool reload_button_clicked(obs_properties_t* props, obs_property_t* property, void* vptr)
 {
 	UNUSED_PARAMETER(props);
 	UNUSED_PARAMETER(property);
-	struct browser_data *data = vptr;
+	struct browser_data* data = vptr;
 	browser_manager_change_css_file(data->manager, data->css_file);
 	browser_manager_reload_page(data->manager);
 	return true;
@@ -210,11 +210,11 @@ static void reload_on_scene(void* vptr)
 		browser_manager_reload_page(data->manager);
 }
 
-static bool restart_button_clicked(obs_properties_t *props, obs_property_t *property, void *vptr)
+static bool restart_button_clicked(obs_properties_t* props, obs_property_t* property, void* vptr)
 {
 	UNUSED_PARAMETER(props);
 	UNUSED_PARAMETER(property);
-	struct browser_data *data = vptr;
+	struct browser_data* data = vptr;
 	browser_manager_restart_browser(data->manager);
 	browser_manager_change_css_file(data->manager, data->css_file);
 	browser_manager_change_url(data->manager, data->url);
@@ -224,30 +224,30 @@ static bool restart_button_clicked(obs_properties_t *props, obs_property_t *prop
 	return true;
 }
 
-static bool is_local_file_modified(obs_properties_t *props, obs_property_t *prop,
-		obs_data_t *settings)
+static bool is_local_file_modified(obs_properties_t* props, obs_property_t* prop,
+                                   obs_data_t* settings)
 {
 	UNUSED_PARAMETER(prop);
 
 	bool enabled = obs_data_get_bool(settings, "is_local_file");
-	obs_property_t *url = obs_properties_get(props, "url");
-	obs_property_t *local_file = obs_properties_get(props, "local_file");
+	obs_property_t* url = obs_properties_get(props, "url");
+	obs_property_t* local_file = obs_properties_get(props, "local_file");
 	obs_property_set_visible(url, !enabled);
 	obs_property_set_visible(local_file, enabled);
 
 	return true;
 }
 
-static obs_properties_t *browser_get_properties(void *vptr)
+static obs_properties_t* browser_get_properties(void* vptr)
 {
 	UNUSED_PARAMETER(vptr);
-	obs_properties_t *props = obs_properties_create();
+	obs_properties_t* props = obs_properties_create();
 
-	obs_property_t *prop = obs_properties_add_bool(props, "is_local_file",
-			obs_module_text("LocalFile"));
+	obs_property_t* prop =
+	  obs_properties_add_bool(props, "is_local_file", obs_module_text("LocalFile"));
 	obs_property_set_modified_callback(prop, is_local_file_modified);
-	obs_properties_add_path(props, "local_file", obs_module_text("LocalFile"),
-			OBS_PATH_FILE, "*.*", NULL);
+	obs_properties_add_path(props, "local_file", obs_module_text("LocalFile"), OBS_PATH_FILE, "*.*",
+	                        NULL);
 
 	obs_properties_add_text(props, "url", obs_module_text("URL"), OBS_TEXT_DEFAULT);
 	obs_properties_add_int(props, "width", obs_module_text("Width"), 1, MAX_BROWSER_WIDTH, 1);
@@ -255,29 +255,33 @@ static obs_properties_t *browser_get_properties(void *vptr)
 	obs_properties_add_int(props, "fps", obs_module_text("FPS"), 1, 60, 1);
 	obs_properties_add_bool(props, "hide_scrollbars", obs_module_text("HideScrollbars"));
 	obs_properties_add_int(props, "zoom", obs_module_text("Zoom"), 1, 500, 1);
-	obs_properties_add_int(props, "scroll_vertical", obs_module_text("ScrollVertical"),
-			0, 10000000, 1);
-	obs_properties_add_int(props, "scroll_horizontal", obs_module_text("ScrollHorizontal"),
-			0, 10000000, 1);
+	obs_properties_add_int(props, "scroll_vertical", obs_module_text("ScrollVertical"), 0, 10000000,
+	                       1);
+	obs_properties_add_int(props, "scroll_horizontal", obs_module_text("ScrollHorizontal"), 0,
+	                       10000000, 1);
 
-	obs_properties_add_button(props, "reload", obs_module_text("ReloadPage"), reload_button_clicked);
+	obs_properties_add_button(props, "reload", obs_module_text("ReloadPage"),
+	                          reload_button_clicked);
 	obs_properties_add_bool(props, "reload_on_scene", obs_module_text("ReloadOnScene"));
 
-	obs_properties_add_path(props, "css_file", obs_module_text("CustomCSS"),
-			OBS_PATH_FILE, "*.css", NULL);
+	obs_properties_add_path(props, "css_file", obs_module_text("CustomCSS"), OBS_PATH_FILE, "*.css",
+	                        NULL);
 
-	obs_properties_add_path(props, "flash_path", obs_module_text("FlashPath"),
-			OBS_PATH_FILE, "*.so", NULL);
-	obs_properties_add_text(props, "flash_version", obs_module_text("FlashVersion"), OBS_TEXT_DEFAULT);
-	obs_properties_add_editable_list(props, "cef_command_line", obs_module_text("CommandLineArguments"),
-			OBS_EDITABLE_LIST_TYPE_STRINGS, NULL, NULL);
+	obs_properties_add_path(props, "flash_path", obs_module_text("FlashPath"), OBS_PATH_FILE,
+	                        "*.so", NULL);
+	obs_properties_add_text(props, "flash_version", obs_module_text("FlashVersion"),
+	                        OBS_TEXT_DEFAULT);
+	obs_properties_add_editable_list(props, "cef_command_line",
+	                                 obs_module_text("CommandLineArguments"),
+	                                 OBS_EDITABLE_LIST_TYPE_STRINGS, NULL, NULL);
 
-	obs_properties_add_button(props, "restart", obs_module_text("RestartBrowser"), restart_button_clicked);
+	obs_properties_add_button(props, "restart", obs_module_text("RestartBrowser"),
+	                          restart_button_clicked);
 
 	return props;
 }
 
-static void browser_get_defaults(obs_data_t *settings)
+static void browser_get_defaults(obs_data_t* settings)
 {
 	obs_data_set_default_string(settings, "url", "http://www.obsproject.com");
 	obs_data_set_default_int(settings, "width", 800);
@@ -288,10 +292,10 @@ static void browser_get_defaults(obs_data_t *settings)
 	obs_data_set_default_int(settings, "zoom", 100);
 }
 
-static void browser_tick(void *vptr, float seconds)
+static void browser_tick(void* vptr, float seconds)
 {
 	UNUSED_PARAMETER(seconds);
-	struct browser_data *data = vptr;
+	struct browser_data* data = vptr;
 	pthread_mutex_lock(&data->textureLock);
 
 	if (!data->activeTexture || !obs_source_showing(data->source)) {
@@ -302,16 +306,16 @@ static void browser_tick(void *vptr, float seconds)
 	lock_browser_manager(data->manager);
 	obs_enter_graphics();
 	gs_texture_set_image(data->activeTexture, get_browser_manager_data(data->manager),
-			data->width * 4, false);
+	                     data->width * 4, false);
 	obs_leave_graphics();
 	unlock_browser_manager(data->manager);
 
 	pthread_mutex_unlock(&data->textureLock);
 }
 
-static void browser_render(void *vptr, gs_effect_t *effect)
+static void browser_render(void* vptr, gs_effect_t* effect)
 {
-	struct browser_data *data = vptr;
+	struct browser_data* data = vptr;
 	pthread_mutex_lock(&data->textureLock);
 
 	if (!data->activeTexture) {
@@ -326,73 +330,70 @@ static void browser_render(void *vptr, gs_effect_t *effect)
 	pthread_mutex_unlock(&data->textureLock);
 }
 
-
-static void browser_mouse_click(void *vptr, const struct obs_mouse_event *event,
-		int32_t type, bool mouse_up, uint32_t click_count)
+static void browser_mouse_click(void* vptr, const struct obs_mouse_event* event, int32_t type,
+                                bool mouse_up, uint32_t click_count)
 {
-	struct browser_data *data = vptr;
-	browser_manager_send_mouse_click(data->manager, event->x, event->y, event->modifiers,
-			type, mouse_up, click_count);
+	struct browser_data* data = vptr;
+	browser_manager_send_mouse_click(data->manager, event->x, event->y, event->modifiers, type,
+	                                 mouse_up, click_count);
 }
 
-static void browser_mouse_move(void *vptr, const struct obs_mouse_event *event,
-		bool mouse_leave)
+static void browser_mouse_move(void* vptr, const struct obs_mouse_event* event, bool mouse_leave)
 {
-	struct browser_data *data = vptr;
+	struct browser_data* data = vptr;
 	browser_manager_send_mouse_move(data->manager, event->x, event->y, event->modifiers,
-			mouse_leave);
+	                                mouse_leave);
 }
 
-static void browser_mouse_wheel(void *vptr, const struct obs_mouse_event *event,
-		int x_delta, int y_delta)
+static void browser_mouse_wheel(void* vptr, const struct obs_mouse_event* event, int x_delta,
+                                int y_delta)
 {
-	struct browser_data *data = vptr;
-	browser_manager_send_mouse_wheel(data->manager, event->x, event->y, event->modifiers,
-			x_delta, y_delta);
+	struct browser_data* data = vptr;
+	browser_manager_send_mouse_wheel(data->manager, event->x, event->y, event->modifiers, x_delta,
+	                                 y_delta);
 }
 
-static void browser_focus(void *vptr, bool focus)
+static void browser_focus(void* vptr, bool focus)
 {
-	struct browser_data *data = vptr;
+	struct browser_data* data = vptr;
 	browser_manager_send_focus(data->manager, focus);
 }
 
-static void browser_key_click(void *vptr, const struct obs_key_event *event, bool key_up)
+static void browser_key_click(void* vptr, const struct obs_key_event* event, bool key_up)
 {
-	struct browser_data *data = vptr;
+	struct browser_data* data = vptr;
 	char chr = 0;
 	if (event->text)
 		chr = event->text[0];
 	blog(LOG_INFO, "Key: %s %d %d", event->text, event->native_vkey, event->native_scancode);
 
-	browser_manager_send_key(data->manager, key_up, event->native_vkey,
-			event->modifiers, chr);
+	browser_manager_send_key(data->manager, key_up, event->native_vkey, event->modifiers, chr);
 }
 
 bool obs_module_load(void)
 {
 	struct obs_source_info info = {};
-	info.id             = "linuxbrowser-source";
-	info.type           = OBS_SOURCE_TYPE_INPUT;
-	info.output_flags   = OBS_SOURCE_VIDEO | OBS_SOURCE_INTERACTION;
+	info.id = "linuxbrowser-source";
+	info.type = OBS_SOURCE_TYPE_INPUT;
+	info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_INTERACTION;
 
-	info.get_name       = browser_get_name;
-	info.create         = browser_create;
-	info.destroy        = browser_destroy;
-	info.update         = browser_update;
-	info.get_width      = browser_get_width;
-	info.get_height     = browser_get_height;
+	info.get_name = browser_get_name;
+	info.create = browser_create;
+	info.destroy = browser_destroy;
+	info.update = browser_update;
+	info.get_width = browser_get_width;
+	info.get_height = browser_get_height;
 	info.get_properties = browser_get_properties;
-	info.get_defaults   = browser_get_defaults;
-	info.video_tick     = browser_tick;
-	info.video_render   = browser_render;
+	info.get_defaults = browser_get_defaults;
+	info.video_tick = browser_tick;
+	info.video_render = browser_render;
 
-	info.activate       = reload_on_scene;
-	info.mouse_click    = browser_mouse_click;
-	info.mouse_move     = browser_mouse_move;
-	info.mouse_wheel    = browser_mouse_wheel;
-	info.focus          = browser_focus;
-	info.key_click      = browser_key_click;
+	info.activate = reload_on_scene;
+	info.mouse_click = browser_mouse_click;
+	info.mouse_move = browser_mouse_move;
+	info.mouse_wheel = browser_mouse_wheel;
+	info.focus = browser_focus;
+	info.key_click = browser_key_click;
 
 	obs_register_source(&info);
 	return true;

--- a/src/plugin/manager.c
+++ b/src/plugin/manager.c
@@ -26,12 +26,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "manager.h"
 
-char *get_shm_name(const char *uid)
+char* get_shm_name(const char* uid)
 {
-	char *shm_name = bzalloc(SHM_MAX);
+	char* shm_name = bzalloc(SHM_MAX);
 	snprintf(shm_name, SHM_MAX, "%s-%s", SHM_NAME, uid);
 	// escape out '/' character
-	char *current_pos = strchr(shm_name+1, '/');
+	char* current_pos = strchr(shm_name + 1, '/');
 	while (current_pos) {
 		*current_pos = '|';
 		current_pos = strchr(current_pos, '/');
@@ -41,33 +41,34 @@ char *get_shm_name(const char *uid)
 
 /* mostly building strings for arguments and env variables for
  * browser process */
-static void spawn_renderer(browser_manager_t *manager)
+static void spawn_renderer(browser_manager_t* manager)
 {
-	char *bin_dir = bstrdup(obs_get_module_binary_path(obs_current_module()));
-	char *s = strrchr(bin_dir, '/');
-	if (s) *(s+1) = '\0';
+	char* bin_dir = bstrdup(obs_get_module_binary_path(obs_current_module()));
+	char* s = strrchr(bin_dir, '/');
+	if (s)
+		*(s + 1) = '\0';
 
-	const char *sflash_path = obs_data_get_string(manager->settings, "flash_path");
-	const char *sflash_version = obs_data_get_string(manager->settings, "flash_version");
+	const char* sflash_path = obs_data_get_string(manager->settings, "flash_path");
+	const char* sflash_version = obs_data_get_string(manager->settings, "flash_version");
 
 	size_t flash_path_size = strlen("--ppapi-flash-path=") + strlen(sflash_path) + 1;
-	char *flash_path = bzalloc(flash_path_size);
+	char* flash_path = bzalloc(flash_path_size);
 	snprintf(flash_path, flash_path_size, "--ppapi-flash-path=%s", sflash_path);
 
 	size_t flash_version_size = strlen("--ppapi-flash-version=") + strlen(sflash_version) + 1;
-	char *flash_version = bzalloc(flash_version_size);
+	char* flash_version = bzalloc(flash_version_size);
 	snprintf(flash_version, flash_version_size, "--ppapi-flash-version=%s", sflash_version);
 
 	size_t renderer_size = strlen(bin_dir) + strlen("browser") + 1;
-	char *renderer = bzalloc(renderer_size);
+	char* renderer = bzalloc(renderer_size);
 	snprintf(renderer, renderer_size, "%sbrowser", bin_dir);
 
-	char *data_path = (char *) obs_get_module_data_path(obs_current_module());
+	char* data_path = (char*) obs_get_module_data_path(obs_current_module());
 
-	obs_data_array_t *command_lines = obs_data_get_array(manager->settings, "cef_command_line");
+	obs_data_array_t* command_lines = obs_data_get_array(manager->settings, "cef_command_line");
 	size_t arg_num = 6 + obs_data_array_count(command_lines);
 
-	char **argv = bzalloc(sizeof(char *) * arg_num);
+	char** argv = bzalloc(sizeof(char*) * arg_num);
 	argv[0] = renderer;
 	argv[1] = data_path;
 	argv[2] = manager->shmname;
@@ -75,13 +76,13 @@ static void spawn_renderer(browser_manager_t *manager)
 	argv[4] = flash_version;
 
 	for (int i = 0; i < arg_num - 6; ++i) {
-		obs_data_t *item = obs_data_array_item(command_lines, i);
-		const char *value = obs_data_get_string(item, "value");
+		obs_data_t* item = obs_data_array_item(command_lines, i);
+		const char* value = obs_data_get_string(item, "value");
 		argv[5 + i] = bstrdup(value);
 		obs_data_release(item);
 	}
 
-	argv[arg_num-1] = NULL;
+	argv[arg_num - 1] = NULL;
 
 	manager->pid = fork();
 	if (manager->pid == 0) {
@@ -90,7 +91,7 @@ static void spawn_renderer(browser_manager_t *manager)
 	}
 
 	for (int i = 0; i < arg_num - 6; ++i) {
-		bfree(argv[5+i]);
+		bfree(argv[5 + i]);
 	}
 	obs_data_array_release(command_lines);
 	bfree(argv);
@@ -101,7 +102,7 @@ static void spawn_renderer(browser_manager_t *manager)
 	bfree(renderer);
 }
 
-static void kill_renderer(browser_manager_t *manager)
+static void kill_renderer(browser_manager_t* manager)
 {
 	if (manager->pid > 0) {
 		kill(manager->pid, SIGTERM);
@@ -110,12 +111,13 @@ static void kill_renderer(browser_manager_t *manager)
 }
 
 /* setting up shared data for the browser process */
-browser_manager_t *create_browser_manager(uint32_t width, uint32_t height, int fps, obs_data_t *settings, const char *uid)
+browser_manager_t* create_browser_manager(uint32_t width, uint32_t height, int fps,
+                                          obs_data_t* settings, const char* uid)
 {
 	if (width > MAX_BROWSER_WIDTH || height > MAX_BROWSER_HEIGHT)
 		return NULL;
 
-	struct browser_manager *manager = bzalloc(sizeof(struct browser_manager));
+	struct browser_manager* manager = bzalloc(sizeof(struct browser_manager));
 	manager->settings = settings;
 
 	manager->qid = msgget(IPC_PRIVATE, S_IRUSR | S_IWUSR);
@@ -134,8 +136,8 @@ browser_manager_t *create_browser_manager(uint32_t width, uint32_t height, int f
 		blog(LOG_ERROR, "ftruncate error");
 		return NULL;
 	}
-	manager->data = (struct shared_data *) mmap(NULL, sizeof(struct shared_data) + MAX_DATA_SIZE,
-				PROT_READ | PROT_WRITE, MAP_SHARED, manager->fd, 0);
+	manager->data = (struct shared_data*) mmap(NULL, sizeof(struct shared_data) + MAX_DATA_SIZE,
+	                                           PROT_READ | PROT_WRITE, MAP_SHARED, manager->fd, 0);
 	if (manager->data == MAP_FAILED) {
 		blog(LOG_ERROR, "mmap error");
 		return NULL;
@@ -155,7 +157,8 @@ browser_manager_t *create_browser_manager(uint32_t width, uint32_t height, int f
 	return manager;
 };
 
-void destroy_browser_manager(browser_manager_t *manager) {
+void destroy_browser_manager(browser_manager_t* manager)
+{
 	kill_renderer(manager);
 	pthread_mutex_destroy(&manager->data->mutex);
 	if (manager->data != NULL && manager->data != MAP_FAILED)
@@ -168,22 +171,22 @@ void destroy_browser_manager(browser_manager_t *manager) {
 	bfree(manager);
 }
 
-void lock_browser_manager(browser_manager_t *manager)
+void lock_browser_manager(browser_manager_t* manager)
 {
 	pthread_mutex_lock(&manager->data->mutex);
 }
 
-void unlock_browser_manager(browser_manager_t *manager)
+void unlock_browser_manager(browser_manager_t* manager)
 {
 	pthread_mutex_unlock(&manager->data->mutex);
 }
 
-uint8_t *get_browser_manager_data(browser_manager_t *manager)
+uint8_t* get_browser_manager_data(browser_manager_t* manager)
 {
 	return &manager->data->data;
 }
 
-void browser_manager_change_url(browser_manager_t *manager, const char *url)
+void browser_manager_change_url(browser_manager_t* manager, const char* url)
 {
 	if (manager->qid == -1)
 		return;
@@ -192,10 +195,10 @@ void browser_manager_change_url(browser_manager_t *manager, const char *url)
 	buf.type = MESSAGE_TYPE_URL;
 	strncpy(buf.text, url, MAX_MESSAGE_SIZE);
 
-	msgsnd(manager->qid, &buf, strlen(url)+1, 0);
+	msgsnd(manager->qid, &buf, strlen(url) + 1, 0);
 }
 
-void browser_manager_change_css_file(browser_manager_t *manager, const char *css_file)
+void browser_manager_change_css_file(browser_manager_t* manager, const char* css_file)
 {
 	if (manager->qid == -1)
 		return;
@@ -204,10 +207,10 @@ void browser_manager_change_css_file(browser_manager_t *manager, const char *css
 	buf.type = MESSAGE_TYPE_CSS;
 	strncpy(buf.text, css_file, MAX_MESSAGE_SIZE);
 
-	msgsnd(manager->qid, &buf, strlen(css_file)+1, 0);
+	msgsnd(manager->qid, &buf, strlen(css_file) + 1, 0);
 }
 
-void browser_manager_change_size(browser_manager_t *manager, uint32_t width, uint32_t height)
+void browser_manager_change_size(browser_manager_t* manager, uint32_t width, uint32_t height)
 {
 	pthread_mutex_lock(&manager->data->mutex);
 
@@ -224,7 +227,7 @@ void browser_manager_change_size(browser_manager_t *manager, uint32_t width, uin
 	pthread_mutex_unlock(&manager->data->mutex);
 }
 
-void browser_manager_set_scrollbars(browser_manager_t *manager, bool show)
+void browser_manager_set_scrollbars(browser_manager_t* manager, bool show)
 {
 	if (manager->qid == -1)
 		return;
@@ -235,7 +238,7 @@ void browser_manager_set_scrollbars(browser_manager_t *manager, bool show)
 	msgsnd(manager->qid, &buf, 1, 0);
 }
 
-void browser_manager_set_zoom(browser_manager_t *manager, uint32_t zoom)
+void browser_manager_set_zoom(browser_manager_t* manager, uint32_t zoom)
 {
 	if (manager->qid == -1)
 		return;
@@ -246,7 +249,7 @@ void browser_manager_set_zoom(browser_manager_t *manager, uint32_t zoom)
 	msgsnd(manager->qid, &buf, sizeof(zoom), 0);
 }
 
-void browser_manager_set_scroll(browser_manager_t *manager, uint32_t vertical, uint32_t horizontal)
+void browser_manager_set_scroll(browser_manager_t* manager, uint32_t vertical, uint32_t horizontal)
 {
 	if (manager->qid == -1)
 		return;
@@ -258,7 +261,7 @@ void browser_manager_set_scroll(browser_manager_t *manager, uint32_t vertical, u
 	msgsnd(manager->qid, &buf, sizeof(vertical) + sizeof(horizontal), 0);
 }
 
-void browser_manager_reload_page(browser_manager_t *manager)
+void browser_manager_reload_page(browser_manager_t* manager)
 {
 	if (manager->qid == -1)
 		return;
@@ -268,7 +271,7 @@ void browser_manager_reload_page(browser_manager_t *manager)
 	msgsnd(manager->qid, &buf, 0, 0);
 }
 
-void browser_manager_restart_browser(browser_manager_t *manager)
+void browser_manager_restart_browser(browser_manager_t* manager)
 {
 	pthread_mutex_lock(&manager->data->mutex);
 	kill_renderer(manager);
@@ -276,8 +279,9 @@ void browser_manager_restart_browser(browser_manager_t *manager)
 	pthread_mutex_unlock(&manager->data->mutex);
 }
 
-void browser_manager_send_mouse_click(browser_manager_t *manager, int32_t x, int32_t y,
-		uint32_t modifiers, int32_t button_type, bool mouse_up, uint32_t click_count)
+void browser_manager_send_mouse_click(browser_manager_t* manager, int32_t x, int32_t y,
+                                      uint32_t modifiers, int32_t button_type, bool mouse_up,
+                                      uint32_t click_count)
 {
 	if (manager->qid == -1)
 		return;
@@ -294,8 +298,8 @@ void browser_manager_send_mouse_click(browser_manager_t *manager, int32_t x, int
 	msgsnd(manager->qid, &buf, sizeof(struct mouse_click_message), 0);
 }
 
-void browser_manager_send_mouse_move(browser_manager_t *manager, int32_t x, int32_t y,
-		uint32_t modifiers, bool mouse_leave)
+void browser_manager_send_mouse_move(browser_manager_t* manager, int32_t x, int32_t y,
+                                     uint32_t modifiers, bool mouse_leave)
 {
 	if (manager->qid == -1)
 		return;
@@ -310,8 +314,8 @@ void browser_manager_send_mouse_move(browser_manager_t *manager, int32_t x, int3
 	msgsnd(manager->qid, &buf, sizeof(struct mouse_move_message), 0);
 }
 
-void browser_manager_send_mouse_wheel(browser_manager_t *manager, int32_t x, int32_t y,
-		uint32_t modifiers, int x_delta, int y_delta)
+void browser_manager_send_mouse_wheel(browser_manager_t* manager, int32_t x, int32_t y,
+                                      uint32_t modifiers, int x_delta, int y_delta)
 {
 	if (manager->qid == -1)
 		return;
@@ -327,7 +331,7 @@ void browser_manager_send_mouse_wheel(browser_manager_t *manager, int32_t x, int
 	msgsnd(manager->qid, &buf, sizeof(struct mouse_wheel_message), 0);
 }
 
-void browser_manager_send_focus(browser_manager_t *manager, bool focus)
+void browser_manager_send_focus(browser_manager_t* manager, bool focus)
 {
 	if (manager->qid == -1)
 		return;
@@ -339,8 +343,8 @@ void browser_manager_send_focus(browser_manager_t *manager, bool focus)
 	msgsnd(manager->qid, &buf, sizeof(struct focus_message), 0);
 }
 
-void browser_manager_send_key(browser_manager_t *manager, bool key_up, uint32_t native_vkey,
-		uint32_t modifiers, char chr)
+void browser_manager_send_key(browser_manager_t* manager, bool key_up, uint32_t native_vkey,
+                              uint32_t modifiers, char chr)
 {
 	if (manager->qid == -1)
 		return;

--- a/src/plugin/manager.h
+++ b/src/plugin/manager.h
@@ -27,32 +27,34 @@ typedef struct browser_manager {
 	int fd;
 	int pid;
 	int qid;
-	char *shmname;
-	obs_data_t *settings;
-	struct shared_data *data;
+	char* shmname;
+	obs_data_t* settings;
+	struct shared_data* data;
 } browser_manager_t;
 
-browser_manager_t *create_browser_manager(uint32_t width, uint32_t height, int fps, obs_data_t *settings, const char *uid);
-void destroy_browser_manager(browser_manager_t *manager);
-void lock_browser_manager(browser_manager_t *manager);
-void unlock_browser_manager(browser_manager_t *manager);
-uint8_t *get_browser_manager_data(browser_manager_t *manager);
+browser_manager_t* create_browser_manager(uint32_t width, uint32_t height, int fps,
+                                          obs_data_t* settings, const char* uid);
+void destroy_browser_manager(browser_manager_t* manager);
+void lock_browser_manager(browser_manager_t* manager);
+void unlock_browser_manager(browser_manager_t* manager);
+uint8_t* get_browser_manager_data(browser_manager_t* manager);
 
-void browser_manager_change_url(browser_manager_t *manager, const char *url);
-void browser_manager_change_css_file(browser_manager_t *manager, const char *css_file);
-void browser_manager_change_size(browser_manager_t *manager, uint32_t width, uint32_t height);
-void browser_manager_set_scrollbars(browser_manager_t *manager, bool show);
-void browser_manager_set_zoom(browser_manager_t *manager, uint32_t zoom);
-void browser_manager_set_scroll(browser_manager_t *manager, uint32_t vertical, uint32_t horizontal);
-void browser_manager_reload_page(browser_manager_t *manager);
-void browser_manager_restart_browser(browser_manager_t *manager);
+void browser_manager_change_url(browser_manager_t* manager, const char* url);
+void browser_manager_change_css_file(browser_manager_t* manager, const char* css_file);
+void browser_manager_change_size(browser_manager_t* manager, uint32_t width, uint32_t height);
+void browser_manager_set_scrollbars(browser_manager_t* manager, bool show);
+void browser_manager_set_zoom(browser_manager_t* manager, uint32_t zoom);
+void browser_manager_set_scroll(browser_manager_t* manager, uint32_t vertical, uint32_t horizontal);
+void browser_manager_reload_page(browser_manager_t* manager);
+void browser_manager_restart_browser(browser_manager_t* manager);
 
-void browser_manager_send_mouse_click(browser_manager_t *manager, int32_t x, int32_t y,
-		uint32_t modifiers, int32_t button_type, bool mouse_up, uint32_t click_count);
-void browser_manager_send_mouse_move(browser_manager_t *manager, int32_t x, int32_t y,
-		uint32_t modifiers, bool mouse_leave);
-void browser_manager_send_mouse_wheel(browser_manager_t *manager, int32_t x, int32_t y,
-		uint32_t modifiers, int x_delta, int y_delta);
-void browser_manager_send_focus(browser_manager_t *manager, bool focus);
-void browser_manager_send_key(browser_manager_t *manager, bool key_up, uint32_t native_vkey,
-		uint32_t modifiers, char chr);
+void browser_manager_send_mouse_click(browser_manager_t* manager, int32_t x, int32_t y,
+                                      uint32_t modifiers, int32_t button_type, bool mouse_up,
+                                      uint32_t click_count);
+void browser_manager_send_mouse_move(browser_manager_t* manager, int32_t x, int32_t y,
+                                     uint32_t modifiers, bool mouse_leave);
+void browser_manager_send_mouse_wheel(browser_manager_t* manager, int32_t x, int32_t y,
+                                      uint32_t modifiers, int x_delta, int y_delta);
+void browser_manager_send_focus(browser_manager_t* manager, bool focus);
+void browser_manager_send_key(browser_manager_t* manager, bool key_up, uint32_t native_vkey,
+                              uint32_t modifiers, char chr);

--- a/src/shared.h
+++ b/src/shared.h
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define MAX_BROWSER_WIDTH 4096
 #define MAX_BROWSER_HEIGHT 4096
-#define MAX_DATA_SIZE MAX_BROWSER_WIDTH * MAX_BROWSER_HEIGHT * 4
+#define MAX_DATA_SIZE MAX_BROWSER_WIDTH* MAX_BROWSER_HEIGHT * 4
 
 struct shared_data {
 	pthread_mutex_t mutex;


### PR DESCRIPTION
I've created this clang-format file trying to represent the current coding style as much as possible (though I didn't figure out how to make it look exactly as it is atm) and formatted the whole master source tree accordingly. Maybe this could be used to avoid formatting problems in new PRs and to keep the source tree uniform.

The branch is opened up for maintainers so you can change the formatting if you'd like to.

Stays unmerged, but opened as there is no need to apply a strict formatting policy at the moment.